### PR TITLE
Added `translateSettings`, for using different delimiters for translate.

### DIFF
--- a/tests/specs/underi18n_spec.js
+++ b/tests/specs/underi18n_spec.js
@@ -51,4 +51,56 @@
 
     });
 
+    describe('different translateSettings', function () {
+        // Clone
+        var local_underi18n = _.clone(underi18n);
+
+        local_underi18n.translateSettings = {
+            regexp: /\%\{(.*?)\}/g,
+            left: '%{',
+            right: '}'
+        };
+
+        var test_el = {
+                'Role %{role}': 'Ο ρόλος %{role}'},
+            t_el = local_underi18n.MessageFactory(test_el);
+
+        it('translate by different delimiter', function () {
+            expect(t_el('Role %{role}', {role: 'διαχειριστής'})).toEqual('Ο ρόλος διαχειριστής');
+        });
+
+
+    });
+
+    describe('different translateSettings for templates', function () {
+        // Clone
+        var local_underi18n = _.clone(underi18n);
+
+        local_underi18n.translateSettings = {
+            regexp: /\%\{(.*?)\}/g,
+            left: '%{',
+            right: '}'
+        };
+
+        var test_en = {
+                'files_label': 'Files',
+                'num_files': 'There are %{num} files in this folder'
+            },
+            templ = '<h1><%= title %></h1>' +
+                '<label><%_ files_label %></label>' +
+                '<span><%_ num_files %></span>',
+            t_en = local_underi18n.MessageFactory(test_en);
+
+        it('will run i18n replacements in an underscore template', function () {
+            var x = _.template(local_underi18n.template(templ, t_en));
+
+            expect(x({title: 'Summary', num: 3})).toEqual(
+                '<h1>Summary</h1>' +
+                '<label>Files</label>' +
+                '<span>There are 3 files in this folder</span>'
+            );
+        });
+
+    });
+
 })(this.jQuery, this._, this.underi18n);

--- a/underi18n.js
+++ b/underi18n.js
@@ -20,32 +20,41 @@
     var underi18n = {
 
         MessageFactory: (function () {
-            var MessageFactory = function (catalog) {
+            var MessageFactory = function (catalog, underi18n) {
                 this.translate = function (msgid, keywords) {
+                    var s = underi18n.translateSettings;
                     var msgstr  = catalog[msgid] ? catalog[msgid] : msgid;
                     if (keywords) {
                         for (var key in keywords) {
-                            msgstr = msgstr.replace('${'+key+'}', keywords[key]);
+                            msgstr = msgstr.replace(s.left + key+ s.right, keywords[key]);
                         }
                     }
                     return msgstr;
                 };
             };
             return function (catalog) {
-                return new MessageFactory(catalog).translate;
+                // this == underi18n
+                return new MessageFactory(catalog, this).translate;
             };
         })(),
 
         template: function (str, factory) {
             var s = this.templateSettings;
+            var st = this.translateSettings;
             return str.replace(s.translate, function (match, code) {
                 return factory(
                     code
                     .replace(/^\s+|\s+$/g, '')
                 );
-            }).replace(/\$\{(.*?)\}/g, function (m, c) {
+            }).replace(st.regexp, function (m, c) {
                 return s.i18nVarLeftDel + c + s.i18nVarRightDel;
             });
+        },
+
+        translateSettings: {
+            regexp: /\$\{(.*?)\}/g,
+            left: '${',
+            right: '}'
         },
 
         templateSettings: {
@@ -57,5 +66,3 @@
 
     return underi18n;
 }));
-
-


### PR DESCRIPTION
Hello,

I really like your plugin implementation for localization.
But I have other separators for variables in my project localization files.
And I made a small addition :) added `translateSettings`

```
// for %{}, 'Hello, %{name}' 

underi18n.translateSettings = {
    regexp: /\%\{(.*?)\}/g,
    left: '%{',
    right: '}'
};

```
